### PR TITLE
PostalCodeHelper::buildList multiple ranges fix

### DIFF
--- a/src/PostalCodeHelper.php
+++ b/src/PostalCodeHelper.php
@@ -64,19 +64,22 @@ class PostalCodeHelper
      */
     protected static function buildList($postalCodes)
     {
+        $resultList = [];
         $postalCodeList = explode(',', $postalCodes);
-        foreach ($postalCodeList as $index => &$postalCodeItem) {
+        foreach ($postalCodeList as $index => $postalCodeItem) {
             $postalCodeItem = trim($postalCodeItem);
             if (strpos($postalCodeItem, ':') !== false) {
                 $postalCodeRange = explode(':', $postalCodeItem);
                 if (is_numeric($postalCodeRange[0]) && is_numeric($postalCodeRange[1])) {
                     $postalCodeRange = range($postalCodeRange[0], $postalCodeRange[1]);
-                    $postalCodeList = array_merge($postalCodeList, $postalCodeRange);
+                    $resultList = array_merge($resultList, $postalCodeRange);
                 }
-                unset($postalCodeList[$index]);
+                continue;
             }
+
+            $resultList[] = $postalCodeItem;
         }
 
-        return $postalCodeList;
+        return $resultList;
     }
 }

--- a/tests/PostalCodeHelperTest.php
+++ b/tests/PostalCodeHelperTest.php
@@ -30,7 +30,16 @@ class PostalCodeHelperTest extends \PHPUnit_Framework_TestCase
         $excludeRule = '35';
         $this->assertEquals(true, PostalCodeHelper::match('34', $includeRule, $excludeRule));
         $this->assertEquals(false, PostalCodeHelper::match('35', $includeRule, $excludeRule));
+
+        // Test multiple lists
+        $includeRule = '2:10, 30:40';
+        $excludeRule = '5:7, 34:36';
+        $this->assertEquals(true, PostalCodeHelper::match('2', $includeRule, $excludeRule));
+        $this->assertEquals(false, PostalCodeHelper::match('5', $includeRule, $excludeRule));
+        $this->assertEquals(true, PostalCodeHelper::match('30', $includeRule, $excludeRule));
+        $this->assertEquals(false, PostalCodeHelper::match('34', $includeRule, $excludeRule));
     }
+    
 
     /**
      * Returns a mock address with the provided postal code.


### PR DESCRIPTION
If you try:
PostalCodeHelper::buildList('5:7,10:12')
you'll get something like:
[6,7,10,11,12]
and "5" will be missing because of the mix of foreach, array_merge and unset($postalCodeList[$index]) .
