### PR TITLE
Missing import

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,34 @@
+# https://editorconfig.org/
+
+root = true
+
+[*]
+trim_trailing_whitespace = true
+insert_final_newline     = true
+end_of_line              = lf
+charset                  = utf-8
+tab_width                = 4
+
+[{*.{awk,bat,c,cpp,d,h,l,re,skl,w32,y},Makefile*}]
+indent_size              = 4
+indent_style             = tab
+
+[*.{dtd,html,inc,php,phpt,rng,wsdl,xml,xsd,xsl}]
+indent_size              = 4
+indent_style             = space
+
+[*.{ac,m4,sh,yml}]
+indent_size              = 2
+indent_style             = space
+
+[*.md]
+indent_style             = space
+max_line_length          = 80
+
+[COMMIT_EDITMSG]
+indent_size              = 4
+indent_style             = space
+max_line_length          = 80
+
+[*.patch]
+trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,34 +1,19 @@
-# https://editorconfig.org/
-
+; top-most EditorConfig file
 root = true
 
+; Unix-style newlines
 [*]
+charset = utf-8
+end_of_line = LF
+insert_final_newline = true
 trim_trailing_whitespace = true
-insert_final_newline     = true
-end_of_line              = lf
-charset                  = utf-8
-tab_width                = 4
 
-[{*.{awk,bat,c,cpp,d,h,l,re,skl,w32,y},Makefile*}]
-indent_size              = 4
-indent_style             = tab
-
-[*.{dtd,html,inc,php,phpt,rng,wsdl,xml,xsd,xsl}]
-indent_size              = 4
-indent_style             = space
-
-[*.{ac,m4,sh,yml}]
-indent_size              = 2
-indent_style             = space
+[*.{php,html,twig}]
+indent_style = space
+indent_size = 4
 
 [*.md]
-indent_style             = space
-max_line_length          = 80
+max_line_length = 80
 
 [COMMIT_EDITMSG]
-indent_size              = 4
-indent_style             = space
-max_line_length          = 80
-
-[*.patch]
-trim_trailing_whitespace = false
+max_line_length = 0

--- a/src/Repository/ZoneRepositoryInterface.php
+++ b/src/Repository/ZoneRepositoryInterface.php
@@ -2,6 +2,8 @@
 
 namespace CommerceGuys\Zone\Repository;
 
+use CommerceGuys\Zone\Model\ZoneInterface;
+
 /**
  * Zone repository interface.
  */


### PR DESCRIPTION
I know this repo is deprecated, but it is still in use by commerceguys/tax. 

I noticed an import missing for doc typehinting.
(also added default php .editorconfig)